### PR TITLE
Use env vars for remote URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_HOME_URL=http://localhost:3000
+NEXT_PUBLIC_SHOP_URL=http://localhost:3001
+NEXT_PUBLIC_CHECKOUT_URL=http://localhost:3002

--- a/3000-home/next.config.js
+++ b/3000-home/next.config.js
@@ -6,15 +6,23 @@ const nextConfig = {
     config.watchOptions = {
       ignored: ['**/node_modules/**', '**/@mf-types/**'],
     };
-    // used for testing build output snapshots
+    // build remote URLs from env variables so deployments can
+    // override where each app is hosted
+    const homeUrl =
+      process.env.NEXT_PUBLIC_HOME_URL || 'http://localhost:3000';
+    const shopUrl =
+      process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001';
+    const checkoutUrl =
+      process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002';
+
     const remotes = {
-      checkout: `checkout@http://localhost:3002/_next/static/${
+      checkout: `checkout@${checkoutUrl}/_next/static/${
         isServer ? 'ssr' : 'chunks'
       }/remoteEntry.js`,
-      home_app: `home_app@http://localhost:3000/_next/static/${
+      home_app: `home_app@${homeUrl}/_next/static/${
         isServer ? 'ssr' : 'chunks'
       }/remoteEntry.js`,
-      shop: `shop@http://localhost:3001/_next/static/${
+      shop: `shop@${shopUrl}/_next/static/${
         isServer ? 'ssr' : 'chunks'
       }/remoteEntry.js`,
     };

--- a/3000-home/pages/home/test-broken-remotes.tsx
+++ b/3000-home/pages/home/test-broken-remotes.tsx
@@ -13,7 +13,8 @@ export default function TestBrokenRemotes() {
       <p>
         Check wrong response for remoteEntry –{' '}
         <Link href="/wrong-entry">/wrong-entry</Link> (on
-        http://localhost:3000/_next/static/chunks/remoteEntry<b>Wrong</b>
+        {`${process.env.NEXT_PUBLIC_HOME_URL || 'http://localhost:3000'}`}
+        /_next/static/chunks/remoteEntry<b>Wrong</b>
         .js)
       </p>
     </div>

--- a/3000-home/pages/index.tsx
+++ b/3000-home/pages/index.tsx
@@ -31,9 +31,12 @@ const Home = () => {
         <li>
           <a
             href="#reloadPage"
-            onClick={() => (window.location.href = 'http://localhost:3000')}
+            onClick={() =>
+              (window.location.href =
+                process.env.NEXT_PUBLIC_HOME_URL || 'http://localhost:3000')
+            }
           >
-            localhost:3000
+            {process.env.NEXT_PUBLIC_HOME_URL || 'http://localhost:3000'}
           </a>
           {' – '}
           <b>home</b>
@@ -41,9 +44,12 @@ const Home = () => {
         <li>
           <a
             href="#reloadPage"
-            onClick={() => (window.location.href = 'http://localhost:3001')}
+            onClick={() =>
+              (window.location.href =
+                process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001')
+            }
           >
-            localhost:3001
+            {process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001'}
           </a>
           {' – '}
           <b>shop</b>
@@ -51,9 +57,12 @@ const Home = () => {
         <li>
           <a
             href="#reloadPage"
-            onClick={() => (window.location.href = 'http://localhost:3002')}
+            onClick={() =>
+              (window.location.href =
+                process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002')
+            }
           >
-            localhost:3002
+            {process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002'}
           </a>
           {' – '}
           <b>checkout</b>
@@ -73,7 +82,9 @@ const Home = () => {
           <tr>
             <td>✅</td>
             <td>
-              Loading remote component (CheckoutTitle) from localhost:3002
+              {`Loading remote component (CheckoutTitle) from ${
+                process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002'
+              }`}
               <br />
               <blockquote>
                 lazy(()=&gt;import(&apos;checkout/CheckoutTitle&apos;))
@@ -103,7 +114,9 @@ const Home = () => {
           <tr>
             <td>✅</td>
             <td>
-              Loading remote component with PNG image from localhost:3001
+              {`Loading remote component with PNG image from ${
+                process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001'
+              }`}
               <br />
               <blockquote>(check publicPath fix in image-loader)</blockquote>
             </td>
@@ -119,7 +132,9 @@ const Home = () => {
           <tr>
             <td>✅</td>
             <td>
-              Loading remote component with SVG from localhost:3001
+              {`Loading remote component with SVG from ${
+                process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001'
+              }`}
               <br />
               <blockquote>(check publicPath fix in url-loader)</blockquote>
             </td>

--- a/3000-home/project.json
+++ b/3000-home/project.json
@@ -69,7 +69,7 @@
       "options": {
         "cypressConfig": "apps/3000-home/cypress.config.ts",
         "testingType": "e2e",
-        "baseUrl": "http://localhost:3000",
+        "baseUrl": "${NEXT_PUBLIC_HOME_URL}",
         "key": "27e40c91-5ac3-4433-8a87-651d10f51cf6"
       },
       "defaultConfiguration": "development",

--- a/3001-shop/components/useCustomRemoteHook.tsx
+++ b/3001-shop/components/useCustomRemoteHook.tsx
@@ -7,6 +7,8 @@ function useCustomRemoteHook(friendID) {
     console.log('some custom hook');
   }, []);
 
-  return 'Custom hook from localhost:3002 works!';
+  const checkoutUrl =
+    process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002';
+  return `Custom hook from ${checkoutUrl} works!`;
 }
 export default useCustomRemoteHook;

--- a/3001-shop/next.config.js
+++ b/3001-shop/next.config.js
@@ -6,15 +6,22 @@ const nextConfig = {
     config.watchOptions = {
       ignored: ['**/node_modules/**', '**/@mf-types/**'],
     };
+    const homeUrl =
+      process.env.NEXT_PUBLIC_HOME_URL || 'http://localhost:3000';
+    const shopUrl =
+      process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001';
+    const checkoutUrl =
+      process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002';
+
     config.plugins.push(
       new NextFederationPlugin({
         name: 'shop',
         filename: 'static/chunks/remoteEntry.js',
         remotes: {
-          home: `home_app@http://localhost:3000/_next/static/${
+          home: `home_app@${homeUrl}/_next/static/${
             isServer ? 'ssr' : 'chunks'
           }/remoteEntry.js`,
-          checkout: `checkout@http://localhost:3002/_next/static/${
+          checkout: `checkout@${checkoutUrl}/_next/static/${
             isServer ? 'ssr' : 'chunks'
           }/remoteEntry.js`,
         },

--- a/3001-shop/pages/shop/index.tsx
+++ b/3001-shop/pages/shop/index.tsx
@@ -14,7 +14,9 @@ const Shop = (props) => {
       <div className="hero">
         <h1>Shop Page</h1>
         <h3 className="title">
-          This is a federated page owned by localhost:3001
+          {`This is a federated page owned by ${
+            process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001'
+          }`}
         </h3>
         <p className="description">
           This application manually exposes <code>page-map</code> and its

--- a/3001-shop/project.json
+++ b/3001-shop/project.json
@@ -115,7 +115,7 @@
       "options": {
         "cypressConfig": "apps/3001-shop/cypress.config.ts",
         "testingType": "e2e",
-        "baseUrl": "http://localhost:3001"
+        "baseUrl": "${NEXT_PUBLIC_SHOP_URL}"
       },
       "defaultConfiguration": "development",
       "configurations": {

--- a/3002-checkout/next.config.js
+++ b/3002-checkout/next.config.js
@@ -6,15 +6,22 @@ const nextConfig = {
     config.watchOptions = {
       ignored: ['**/node_modules/**', '**/@mf-types/**'],
     };
+    const homeUrl =
+      process.env.NEXT_PUBLIC_HOME_URL || 'http://localhost:3000';
+    const shopUrl =
+      process.env.NEXT_PUBLIC_SHOP_URL || 'http://localhost:3001';
+    const checkoutUrl =
+      process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002';
+
     config.plugins.push(
       new NextFederationPlugin({
         name: 'checkout',
         filename: 'static/chunks/remoteEntry.js',
         remotes: {
-          home: `home_app@http://localhost:3000/_next/static/${
+          home: `home_app@${homeUrl}/_next/static/${
             isServer ? 'ssr' : 'chunks'
           }/remoteEntry.js`,
-          shop: `shop@http://localhost:3001/_next/static/${
+          shop: `shop@${shopUrl}/_next/static/${
             isServer ? 'ssr' : 'chunks'
           }/remoteEntry.js`,
         },

--- a/3002-checkout/pages/checkout/index.tsx
+++ b/3002-checkout/pages/checkout/index.tsx
@@ -11,7 +11,9 @@ const Checkout = (props) => (
     <div className="hero">
       <h1>checkout page</h1>
       <h3 className="title">
-        This is a federated page owned by localhost:3002!!
+        {`This is a federated page owned by ${
+          process.env.NEXT_PUBLIC_CHECKOUT_URL || 'http://localhost:3002'
+        }!!`}
       </h3>
       <p className="description">
         This application serves code from <code>src/</code> folder.

--- a/3002-checkout/project.json
+++ b/3002-checkout/project.json
@@ -69,7 +69,7 @@
       "options": {
         "cypressConfig": "apps/3002-checkout/cypress.config.ts",
         "testingType": "e2e",
-        "baseUrl": "http://localhost:3002"
+        "baseUrl": "${NEXT_PUBLIC_CHECKOUT_URL}"
       },
       "defaultConfiguration": "development",
       "configurations": {


### PR DESCRIPTION

<img width="1725" alt="Screenshot 2025-06-19 at 4 50 25 PM" src="https://github.com/user-attachments/assets/6ab3b911-922d-468a-b4a1-5ccf890b7667" />
## Summary
- externalize remote URLs through NEXT_PUBLIC_* env vars
- update page text and links to use env vars
- adjust Cypress baseUrl to use env vars
- document variables in `.env.example`

## Testing
- `pnpm -r build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854663481e4832b9f911a4f02256371